### PR TITLE
Fix IE 8 expected identifier, string or number error

### DIFF
--- a/lib/Google.js
+++ b/lib/Google.js
@@ -83,7 +83,7 @@
 
 		return {
 			then: promiseError,
-			catch: promiseError,
+			'catch': promiseError,
 			fail: promiseError
 		};
 	};


### PR DESCRIPTION
"Catch" is a reserved word in IE8